### PR TITLE
Refactor Dockerfiles to use multi-stage builds

### DIFF
--- a/genkit/Dockerfile
+++ b/genkit/Dockerfile
@@ -1,14 +1,21 @@
-FROM node:22-alpine
+# Builder stage
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 
 COPY package*.json ./
-
 RUN npm install
 
 COPY . .
-
 RUN npm run build
+
+# Production stage
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/node_modules ./node_modules
 
 ENV NODE_ENV=production
 

--- a/socket.io/Dockerfile
+++ b/socket.io/Dockerfile
@@ -1,14 +1,21 @@
-FROM node:22-alpine
+# Builder stage
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 
 COPY package*.json ./
-
 RUN npm install
 
 COPY . .
-
 RUN npm run build
+
+# Production stage
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/node_modules ./node_modules
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
This change modifies the Dockerfiles in `genkit` and `socket.io` to implement multi-stage builds.

The first stage, named 'builder', is responsible for installing dependencies (including devDependencies like npm) and building the application.

The second stage creates a lean production image by copying only the necessary artifacts (the `dist` folder and production `node_modules`) from the 'builder' stage.

This approach significantly reduces the final image size and improves security by excluding npm and other development tools from the production environment.